### PR TITLE
Minor improvements to the interface and fixed unit tests

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,11 +1,14 @@
 # Version changes
 
 
-## Un-released
+## Version 1.0.2
 
 * Some code re-factoring and minor improvements.
 * Fix of leaking memory: jobs, commands and workers will now be cleaned up if not heard from for an hour.
 * Added continuous integration.
+* `is_done()` calls may now throw an exception if an error has been encountered or a command has timed out. In the case
+    of job handlers, only a failing/timed out start command will result in an exception being thrown.
+* It is now possible to access the command response codes as `response_code` from the command handler.
 
 ## Version 1.0.1
 

--- a/file_writer_control/CommandChannel.py
+++ b/file_writer_control/CommandChannel.py
@@ -7,7 +7,10 @@ from typing import List, Union, Dict
 import atexit
 from datetime import datetime
 
-from file_writer_control.InThreadStatusTracker import InThreadStatusTracker, DEAD_ENTITY_TIME_LIMIT
+from file_writer_control.InThreadStatusTracker import (
+    InThreadStatusTracker,
+    DEAD_ENTITY_TIME_LIMIT,
+)
 from file_writer_control.WorkerStatus import WorkerStatus
 from file_writer_control.JobStatus import JobStatus
 from file_writer_control.CommandStatus import CommandStatus
@@ -146,14 +149,21 @@ class CommandChannel(object):
             status_update = self.status_queue.get()
             status_updater_map[type(status_update)](status_update)
 
-
-        for entity in list(self.map_of_workers.values()) + list(self.map_of_commands.values()) + list(self.map_of_jobs.values()):
+        for entity in (
+            list(self.map_of_workers.values())
+            + list(self.map_of_commands.values())
+            + list(self.map_of_jobs.values())
+        ):
             entity.check_if_outdated(current_time)
 
         def pruner(entities_dictionary):
             for key in list(entities_dictionary.keys()):
-                if entities_dictionary[key].last_update + DEAD_ENTITY_TIME_LIMIT < current_time:
+                if (
+                    entities_dictionary[key].last_update + DEAD_ENTITY_TIME_LIMIT
+                    < current_time
+                ):
                     del entities_dictionary[key]
+
         pruner(self.map_of_commands)
         pruner(self.map_of_workers)
         pruner(self.map_of_jobs)

--- a/file_writer_control/CommandHandler.py
+++ b/file_writer_control/CommandHandler.py
@@ -30,10 +30,14 @@ class CommandHandler:
         """
         :return: True if the command completed successfully. False otherwise.
         """
-        return (
-            self.command_channel.get_command(self.command_id).state
-            == CommandState.SUCCESS
-        )
+        current_state = self.command_channel.get_command(self.command_id).state
+        if current_state == CommandState.ERROR:
+            raise RuntimeError(
+                f'Command failed with error message "{self.get_message()}".'
+            )
+        if current_state == CommandState.TIMEOUT_RESPONSE:
+            raise RuntimeError("Timed out while trying to send command.")
+        return current_state == CommandState.SUCCESS
 
     def get_message(self) -> str:
         """

--- a/file_writer_control/CommandStatus.py
+++ b/file_writer_control/CommandStatus.py
@@ -1,5 +1,6 @@
 from enum import Enum, auto
 from datetime import datetime, timedelta
+from typing import Optional
 
 COMMAND_STATUS_TIMEOUT = timedelta(seconds=30)
 
@@ -28,6 +29,7 @@ class CommandStatus(object):
         self._last_update = datetime.now()
         self._state = CommandState.NO_COMMAND
         self._message = ""
+        self._response_code = None
 
     def __eq__(self, other_status: "CommandStatus"):
         if not isinstance(other_status, CommandStatus):
@@ -36,6 +38,7 @@ class CommandStatus(object):
             other_status.command_id == self.command_id
             and other_status.job_id == self.job_id
             and other_status.state == self.state
+            and other_status.response_code == self.response_code
         )
 
     def update_status(self, new_status: "CommandStatus"):
@@ -49,6 +52,7 @@ class CommandStatus(object):
                 f"Command id of status update is not correct ({self.command_id} vs {new_status.command_id})"
             )
         self._state = new_status.state
+        self._response_code = new_status.response_code
         if new_status.message:
             self._message = new_status.message
         self._last_update = new_status.last_update
@@ -59,11 +63,26 @@ class CommandStatus(object):
         :param current_time: The current time
         """
         if (
-                self.state != CommandState.SUCCESS
-                and self.state != CommandState.ERROR
-                and current_time - self.last_update > COMMAND_STATUS_TIMEOUT
+            self.state != CommandState.SUCCESS
+            and self.state != CommandState.ERROR
+            and current_time - self.last_update > COMMAND_STATUS_TIMEOUT
         ):
             self._state = CommandState.TIMEOUT_RESPONSE
+
+    @property
+    def response_code(self) -> Optional[int]:
+        """
+        A code that mirrors the result of a command if a response has been received. Is set to None otherwise.
+        """
+        return self._response_code
+
+    @response_code.setter
+    def response_code(self, new_code: int):
+        """
+        Set the current response code.
+        """
+        self._response_code = new_code
+        self._last_update = datetime.now()
 
     @property
     def job_id(self) -> str:

--- a/file_writer_control/InThreadStatusTracker.py
+++ b/file_writer_control/InThreadStatusTracker.py
@@ -77,7 +77,11 @@ class InThreadStatusTracker:
         after the limit_time.
         :param limit_time: The cut-off time for deciding which updates should be sent to the status queue.
         """
-        for entity in list(self.known_workers.values()) + list(self.known_jobs.values()) + list(self.known_commands.values()):
+        for entity in (
+            list(self.known_workers.values())
+            + list(self.known_jobs.values())
+            + list(self.known_commands.values())
+        ):
             if entity.last_update >= limit_time:
                 self.queue.put(entity)
 
@@ -115,7 +119,11 @@ class InThreadStatusTracker:
         reached.
         """
         now = datetime.now()
-        for entity in list(self.known_workers.values()) + list(self.known_jobs.values()) + list(self.known_commands.values()):
+        for entity in (
+            list(self.known_workers.values())
+            + list(self.known_jobs.values())
+            + list(self.known_commands.values())
+        ):
             entity.check_if_outdated(now)
 
     def prune_dead_entities(self, current_time: datetime):
@@ -123,10 +131,15 @@ class InThreadStatusTracker:
         Will remove old jobs, workers and commands that have not been updated recently.
         :return:
         """
+
         def pruner(entities_dictionary):
             for key in list(entities_dictionary.keys()):
-                if entities_dictionary[key].last_update + DEAD_ENTITY_TIME_LIMIT < current_time:
+                if (
+                    entities_dictionary[key].last_update + DEAD_ENTITY_TIME_LIMIT
+                    < current_time
+                ):
                     del entities_dictionary[key]
+
         pruner(self.known_workers)
         pruner(self.known_commands)
         pruner(self.known_jobs)
@@ -142,10 +155,10 @@ class InThreadStatusTracker:
         new_job_state = extract_job_state_from_answer(answer)
         if new_job_state is not None:
             self.known_jobs[answer.job_id].state = new_job_state
-        self.known_commands[
-            answer.command_id
-        ].state = extract_state_from_command_answer(answer)
-        self.known_commands[answer.command_id].message = answer.message
+        current_command = self.known_commands[answer.command_id]
+        current_command.state = extract_state_from_command_answer(answer)
+        current_command.message = answer.message
+        current_command.response_code = Response.status_code
         self.known_jobs[answer.job_id].message = answer.message
 
     def process_status(self, status_update: StatusMessage):

--- a/file_writer_control/JobHandler.py
+++ b/file_writer_control/JobHandler.py
@@ -43,7 +43,12 @@ class JobHandler:
         :return: True if job was completed without errors. False otherwise.
         .. note:: If the job was completed with errors, this call will return False.
         """
-        return self.worker_finder.get_job_state(self._job_id) == JobState.DONE
+        current_job_state = self.worker_finder.get_job_state(self._job_id)
+        if current_job_state == JobState.ERROR:
+            raise RuntimeError(f'Job failed with error message "{self.get_message()}".')
+        if current_job_state == JobState.TIMEOUT:
+            raise RuntimeError("Timed out while trying to start write job.")
+        return current_job_state == JobState.DONE
 
     def get_message(self) -> str:
         """

--- a/file_writer_control/JobStatus.py
+++ b/file_writer_control/JobStatus.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta
 
 JOB_STATUS_TIMEOUT = timedelta(seconds=5)
 
+
 class JobState(Enum):
     """
     The state of a job.
@@ -53,9 +54,9 @@ class JobStatus:
         :param current_time: The current time
         """
         if (
-                self.state != JobState.DONE
-                and self.state != JobState.ERROR
-                and current_time - self.last_update > JOB_STATUS_TIMEOUT
+            self.state != JobState.DONE
+            and self.state != JobState.ERROR
+            and current_time - self.last_update > JOB_STATUS_TIMEOUT
         ):
             self._state = JobState.TIMEOUT
 

--- a/file_writer_control/WorkerCommandChannel.py
+++ b/file_writer_control/WorkerCommandChannel.py
@@ -89,12 +89,9 @@ class WorkerCommandChannel(WorkerFinder):
                 list_of_jobs = self.command_channel.list_jobs()
                 for job in list_of_jobs:
                     if job.job_id == do_job.job_id:
-                        if (
-                            job.state == JobState.WRITING
-                            or job.state == JobState.DONE
-                        ):
+                        if job.state == JobState.WRITING or job.state == JobState.DONE:
                             return
                         elif job_started_time + SEND_JOB_TIMEOUT < time.time():
                             waiting_to_send_job = True
                         break
-            time.sleep(1.0/loop_poll_rate)
+            time.sleep(1.0 / loop_poll_rate)

--- a/file_writer_control/WorkerFinder.py
+++ b/file_writer_control/WorkerFinder.py
@@ -59,7 +59,7 @@ class WorkerFinderBase:
             job_id=job_id,
             service_id=service_id,
             command_id=command_id,
-            stop_time=stop_time
+            stop_time=stop_time,
         )
         self.command_channel.add_command_id(job_id=job_id, command_id=command_id)
         self.send_command(message)

--- a/file_writer_control/WorkerStatus.py
+++ b/file_writer_control/WorkerStatus.py
@@ -52,8 +52,8 @@ class WorkerStatus(object):
         :param current_time: The current time
         """
         if (
-                self.state != WorkerState.UNAVAILABLE
-                and current_time - self.last_update > STATUS_MESSAGE_TIMEOUT
+            self.state != WorkerState.UNAVAILABLE
+            and current_time - self.last_update > STATUS_MESSAGE_TIMEOUT
         ):
             self._state = WorkerState.UNAVAILABLE
 


### PR DESCRIPTION
## Changes

* `is_done()` calls may now throw an exception if an error has been encountered or a command has timed out. In the case
    of job handlers, only a failing/timed out start command will result in an exception being thrown.
* It is now possible to access the command response codes as `response_code` from the command handler.