### PR TITLE
ECDC-2622 Refactor stop fw now

### DIFF
--- a/file_writer_control/WorkerFinder.py
+++ b/file_writer_control/WorkerFinder.py
@@ -76,13 +76,7 @@ class WorkerFinderBase:
         :param job_id: The job identifier of the currently running file-writer job.
         :return: A CommandHandler instance for (more) easily checking the outcome of the "stop now" command.
         """
-        command_id = str(uuid.uuid1())
-        message = serialise_stop(
-            job_id=job_id, service_id=service_id, command_id=command_id, stop_time=0
-        )
-        self.command_channel.add_command_id(job_id=job_id, command_id=command_id)
-        self.send_command(message)
-        return CommandHandler(self.command_channel, command_id)
+        return self.try_send_stop_time(service_id, job_id, datetime.now())
 
     def list_known_workers(self) -> List[WorkerStatus]:
         """

--- a/tests/test_worker_finder.py
+++ b/tests/test_worker_finder.py
@@ -68,7 +68,6 @@ def test_try_send_stop_now():
     assert message.service_id == service_id
     assert message.job_id == job_id
     assert message.command_id == result.command_id
-    assert message.stop_time == 0
 
 
 def test_get_job_status():


### PR DESCRIPTION
Refactoring of code. Decided to keep the function try_send_stop_now to avoid breaking anything in other repositories etc.
Really just a wrapped call of try_send_stop_time with datetime.now() as argument for the stop_time.