### PR TITLE
Accept manual job id and modify CLI 

### DIFF
--- a/cli/start_file_writer.py
+++ b/cli/start_file_writer.py
@@ -31,6 +31,14 @@ def cli_parser() -> argparse.Namespace:
         help="Name of the output file, e.g., `<filename>.nxs`.",
     )
     fw_parser.add_argument(
+        "-j",
+        "--job-id",
+        metavar="job_id",
+        type=str,
+        help="The job identifier of the currently running file-writer job. "
+        "The job identifier should be a valid UUID.",
+    )
+    fw_parser.add_argument(
         "-c",
         "--config",
         metavar="json_config",
@@ -117,6 +125,7 @@ def prepare_write_job(args: argparse.Namespace) -> WriteJob:
     global ACK_TIMEOUT
 
     file_name = args.filename
+    job_id = args.job_id
     host = args.broker
     topic = args.topic
     config = args.config
@@ -125,12 +134,17 @@ def prepare_write_job(args: argparse.Namespace) -> WriteJob:
     JOB_HANDLER = JobHandler(worker_finder=command_channel)
     with open(config, "r") as f:
         nexus_structure = f.read()
-    write_job = WriteJob(
-        nexus_structure,
-        file_name,
-        host,
-        datetime.now(),
-    )
+    if job_id:
+        write_job = WriteJob(
+            nexus_structure, file_name, host, datetime.now(), job_id=job_id
+        )
+    else:
+        write_job = WriteJob(
+            nexus_structure,
+            file_name,
+            host,
+            datetime.now(),
+        )
     return write_job
 
 

--- a/file_writer_control/WriteJob.py
+++ b/file_writer_control/WriteJob.py
@@ -16,6 +16,7 @@ class WriteJob:
         broker: str,
         start_time: datetime,
         stop_time: datetime = None,
+        job_id="",
         instrument_name: str = "",
         run_name: str = "",
         metadata: str = "",
@@ -23,7 +24,14 @@ class WriteJob:
     ):
         self.structure = nexus_structure
         self.file = file_name
-        self.job_id = str(uuid.uuid1())
+        if job_id:
+            try:
+                uuid.UUID(job_id)
+                self.job_id = job_id
+            except ValueError as e:
+                raise RuntimeError("Job ID should be a valid UUID (v1).") from e
+        else:
+            self.job_id = str(uuid.uuid1())
         self.start = start_time
         if stop_time is None:
             self.stop = self.start + timedelta(days=365.25 * 10)


### PR DESCRIPTION
The FWContol has been change such that user generated valid job identifiers now accepted. The ID should be a valid UUID.

The CLI has been modified accordingly. Basic usage:

- `python start_file_writer.py -f <filename> -j <job_id> -c <config> -t <topic>`

If ID is not provided, FWControl generates one as usual.

To generate a valid ID, simply open a terminal, and:

1. `python`
2. `import uuid`
3. `_id = str(uuid.uuid1())`
4. `_id`

Copy `_id` and paste it into the CLI. 