### PR TITLE
Use pool in CLIs

### DIFF
--- a/cli/start_file_writer.py
+++ b/cli/start_file_writer.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta
 from time import time as current_time
 from typing import Optional, Tuple
 
-from file_writer_control import JobHandler, JobState, WorkerCommandChannel, WriteJob
+from file_writer_control import JobHandler, JobState, WorkerJobPool, WriteJob
 
 JOB_HANDLER: JobHandler
 ACK_TIMEOUT: float
@@ -60,7 +60,16 @@ def cli_parser() -> argparse.Namespace:
         metavar="consume_topic",
         type=str,
         required=True,
-        help="Name of the Kafka topic to listen to commands and send status to.",
+        help="Name of the Kafka topic to listen to" " commands and send status to.",
+    )
+    fw_parser.add_argument(
+        "-p",
+        "--job-pool-topic",
+        metavar="job_pool_topic",
+        type=str,
+        required=True,
+        help="The Kafka topic that the available file-writers"
+        " are listening to for write jobs.",
     )
     fw_parser.add_argument(
         "--timeout",
@@ -127,10 +136,11 @@ def prepare_write_job(args: argparse.Namespace) -> WriteJob:
     file_name = args.filename
     job_id = args.job_id
     host = args.broker
-    topic = args.command_status_topic
+    command_topic = args.command_status_topic
+    pool_topic = args.job_pool_topic
     config = args.config
     ACK_TIMEOUT = args.timeout
-    command_channel = WorkerCommandChannel(f"{host}/{topic}")
+    command_channel = WorkerJobPool(f"{host}/{pool_topic}", f"{host}/{command_topic}")
     JOB_HANDLER = JobHandler(worker_finder=command_channel)
     with open(config, "r") as f:
         nexus_structure = f.read()

--- a/cli/start_file_writer.py
+++ b/cli/start_file_writer.py
@@ -170,7 +170,13 @@ def inform_status() -> None:
 
 
 def validate_namespace(args: argparse.Namespace) -> None:
-    argument_list = [args.filename, args.config, args.broker, args.command_status_topic]
+    argument_list = [
+        args.filename,
+        args.config,
+        args.broker,
+        args.command_status_topic,
+        args.job_pool_topic,
+    ]
     for arg in argument_list:
         is_empty(arg)
 

--- a/cli/stop_file_writer.py
+++ b/cli/stop_file_writer.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta
 from time import time as current_time
 
 from cli.start_file_writer import is_empty
-from file_writer_control import JobHandler, JobState, WorkerCommandChannel
+from file_writer_control import JobHandler, JobState, WorkerJobPool
 
 
 def cli_parser() -> argparse.Namespace:
@@ -49,6 +49,15 @@ def cli_parser() -> argparse.Namespace:
         help="Name of the Kafka topic to listen to commands and send status to.",
     )
     fw_parser.add_argument(
+        "-p",
+        "--job-pool-topic",
+        metavar="job_pool_topic",
+        type=str,
+        required=True,
+        help="The Kafka topic that the available file-writers"
+        " are listening to for write jobs.",
+    )
+    fw_parser.add_argument(
         "--timeout",
         metavar="ack_timeout",
         type=float,
@@ -63,8 +72,9 @@ def cli_parser() -> argparse.Namespace:
 
 def create_job_handler(args: argparse.Namespace, job_id: str) -> JobHandler:
     host = args.broker
-    topic = args.topic
-    command_channel = WorkerCommandChannel(f"{host}/{topic}")
+    command_topic = args.command_status_topic
+    pool_topic = args.job_pool_topic
+    command_channel = WorkerJobPool(f"{host}/{pool_topic}", f"{host}/{command_topic}")
     job_handler = JobHandler(worker_finder=command_channel, job_id=job_id)
     # Required for formation of the handler.
     time.sleep(3)
@@ -109,11 +119,11 @@ def validate_namespace() -> None:
         sys.exit()
     argument_list = [
         cli_args.stop,
-        cli_args.stop_after,
         cli_args.broker,
-        cli_args.topic,
+        cli_args.command_status_topic,
+        cli_args.job_pool_topic,
     ]
-    for arg in argument_list:
+    for arg in argument_list + cli_args.stop_after:
         if arg:
             is_empty(arg)
 


### PR DESCRIPTION
We now use `WorkerJobPool` in command line interfaces. With this change one requires to provide a second Kafka topic for job pool (should be defined as `job-pool-uri` in file writer config).

Basic usage:

- `python start_file_writer.py -f <filename> -c <config> -t <command_topic> -p <job_pool_topic>` to start
- `python stop_file_writer.py -s <job_id>  -t <command_topic> -p <job_pool_topic>` to stop

All other optionals (providing job id, stop time etc.) remains unchanged.