### PR TITLE
Entry point for command line methods

### DIFF
--- a/cli/start_file_writer.py
+++ b/cli/start_file_writer.py
@@ -227,10 +227,14 @@ def set_time_and_stop() -> None:
         print("Input should be a float.")
 
 
-if __name__ == "__main__":
+def start_writer():
     # Catch ctrl-c
     signal.signal(signal.SIGINT, ask_user_action)
     # Main
     cli_args = cli_parser()
     validate_namespace(cli_args)
     file_writer(cli_args)
+
+
+if __name__ == "__main__":
+    start_writer()

--- a/cli/stop_file_writer.py
+++ b/cli/stop_file_writer.py
@@ -100,27 +100,27 @@ def verify_write_job(job_handler: JobHandler) -> None:
         )
 
 
-def validate_namespace() -> None:
-    if cli_args.stop and cli_args.stop_after:
+def validate_namespace(args: argparse.Namespace) -> None:
+    if args.stop and args.stop_after:
         print(
             "Positional arguments [-s --stop] and [-sa --stop_after] cannot "
             "be used simultaneously."
         )
         sys.exit()
     argument_list = [
-        cli_args.stop,
-        cli_args.stop_after,
-        cli_args.broker,
-        cli_args.topic,
+        args.stop,
+        args.stop_after,
+        args.broker,
+        args.topic,
     ]
     for arg in argument_list:
         if arg:
             is_empty(arg)
 
 
-if __name__ == "__main__":
+def stop_writer():
     cli_args = cli_parser()
-    validate_namespace()
+    validate_namespace(cli_args)
 
     _id = cli_args.stop if cli_args.stop else cli_args.stop_after[0]
     handler = create_job_handler(cli_args, _id)
@@ -130,3 +130,7 @@ if __name__ == "__main__":
         stop_write_job(cli_args, handler)
     else:
         stop_write_job_now(handler)
+
+
+if __name__ == "__main__":
+    stop_writer()

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 import os
 
 from setuptools import find_packages, setup
+
 from file_writer_control._version import version
 
 DESCRIPTION = (
@@ -27,6 +28,12 @@ setup(
     url="https://github.com/ess-dmsc/file_writer_control",
     license="BSD 2-Clause License",
     packages=find_packages(exclude=["tests", "examples"]),
+    entry_points={
+        "console_scripts": [
+            "start_file_writer = cli.start_file_writer:start_writer",
+            "stop_file_writer = cli.stop_file_writer:stop_writer",
+        ],
+    },
     python_requires=">=3.6.0",
     install_requires=["kafka-python>=2.0", "ess-streaming-data-types>=0.10.0"],
 )


### PR DESCRIPTION
After `pip install .` in root folder, you can use command line as `start_file_writer --blah blah` or `stop_file_writer --blah blah`
