### PR TITLE
Various bug fixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Version changes
 
+## Version 1.1.7
+
+* Fixed command timeout configuration.
+* Fixed serious datetime bug.
+
 ## Version 1.1.6
 
 * Added the ability to configure the command-timeout.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Version changes
 
+## Version 1.1.6
+
+* Added the ability to configure the command-timeout.
+* New commands now get the initial state: "waiting for response" when they are sent.
+
 ## Version 1.1.4
 
 * Simplify importing of classes.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 * Fixed command timeout configuration.
 * Fixed serious datetime bug.
+* Reverted removal of `stop_now()` it directly calls the `abort_write_job()` function.
 
 ## Version 1.1.6
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,12 +4,17 @@
 
 * Fixed command timeout configuration.
 * Fixed serious datetime bug.
-* Reverted removal of `stop_now()` it directly calls the `abort_write_job()` function.
+* Reverted removal of `stop_now()`, it now directly calls the `abort_write_job()` function.
+* Reverted removal of `try_send_stop_now()`, it now directly calls the `try_send_abort()` function.
 
 ## Version 1.1.6
 
 * Added the ability to configure the command-timeout.
 * New commands now get the initial state: "waiting for response" when they are sent.
+
+## Version 1.1.5
+
+* Implemented command line interface script to library.
 
 ## Version 1.1.4
 

--- a/file_writer_control/CommandChannel.py
+++ b/file_writer_control/CommandChannel.py
@@ -7,7 +7,7 @@ from typing import Dict, List, Union
 from kafka import KafkaConsumer
 from kafka.errors import NoBrokersAvailable
 
-from file_writer_control.CommandStatus import CommandStatus
+from file_writer_control.CommandStatus import CommandStatus, CommandState
 from file_writer_control.InThreadStatusTracker import (
     DEAD_ENTITY_TIME_LIMIT,
     InThreadStatusTracker,
@@ -104,6 +104,7 @@ class CommandChannel(object):
         """
         if command_id not in self.map_of_commands:
             self.map_of_commands[command_id] = CommandStatus(job_id, command_id)
+            self.map_of_commands[command_id].state = CommandState.WAITING_RESPONSE
 
     def stop_thread(self):
         """

--- a/file_writer_control/CommandChannel.py
+++ b/file_writer_control/CommandChannel.py
@@ -2,7 +2,7 @@ import atexit
 import threading
 from datetime import datetime
 from queue import Queue
-from typing import Dict, List, Union
+from typing import Dict, List, Union, Optional
 
 from kafka import KafkaConsumer
 from kafka.errors import NoBrokersAvailable
@@ -120,12 +120,14 @@ class CommandChannel(object):
     def __del__(self):
         self.stop_thread()
 
-    def update_workers(self, current_time: datetime = datetime.now()):
+    def update_workers(self, current_time: Optional[datetime] = None):
         """
         Update the list of known workers, jobs and commands. This is a non-blocking call but it might take some time
         to execute if the queue of updates is long. This member function is called by many of the other member functions
         in this class.
         """
+        if current_time is None:
+            current_time = datetime.now()
 
         def handle_worker_status(status_update):
             if status_update.service_id not in self.map_of_workers:

--- a/file_writer_control/CommandHandler.py
+++ b/file_writer_control/CommandHandler.py
@@ -2,6 +2,7 @@ from file_writer_control.CommandChannel import CommandChannel
 from file_writer_control.CommandStatus import CommandState
 from datetime import timedelta
 
+
 class CommandHandler:
     """
     A stand in for (more easily) checking the state of a command sent to a file-writer.

--- a/file_writer_control/CommandHandler.py
+++ b/file_writer_control/CommandHandler.py
@@ -1,6 +1,6 @@
 from file_writer_control.CommandChannel import CommandChannel
 from file_writer_control.CommandStatus import CommandState
-
+from datetime import timedelta
 
 class CommandHandler:
     """
@@ -48,3 +48,9 @@ class CommandHandler:
         if command is None:
             return ""
         return command.message
+
+    def set_timeout(self, new_timeout: timedelta):
+        self.command_channel.get_command(self.command_id).timeout = new_timeout
+
+    def get_timeout(self):
+        return self.command_channel.get_command(self.command_id).timeout

--- a/file_writer_control/CommandStatus.py
+++ b/file_writer_control/CommandStatus.py
@@ -23,7 +23,8 @@ class CommandStatus(object):
     The status of a command.
     """
 
-    def __init__(self, job_id: str, command_id: str):
+    def __init__(self, job_id: str, command_id: str, command_timeout: timedelta = COMMAND_STATUS_TIMEOUT):
+        self._command_timeout = command_timeout
         self._job_id = job_id
         self._command_id = command_id
         self._last_update = datetime.now()
@@ -66,7 +67,7 @@ class CommandStatus(object):
             self.state != CommandState.SUCCESS
             and self.state != CommandState.ERROR
             and self.state != CommandState.TIMEOUT_RESPONSE
-            and current_time - self.last_update > COMMAND_STATUS_TIMEOUT
+            and current_time - self.last_update > self._command_timeout
         ):
             self._state = CommandState.TIMEOUT_RESPONSE
             self._last_update = current_time
@@ -132,3 +133,14 @@ class CommandStatus(object):
         The local time stamp of the last update of the status of the command.
         """
         return self._last_update
+
+    @property
+    def timeout(self) -> timedelta:
+        """
+        Timeout for waiting for response to command.
+        """
+        return self._command_timeout
+
+    @timeout.setter
+    def timeout(self, new_timeout: timedelta):
+        self._command_timeout = new_timeout

--- a/file_writer_control/CommandStatus.py
+++ b/file_writer_control/CommandStatus.py
@@ -23,7 +23,12 @@ class CommandStatus(object):
     The status of a command.
     """
 
-    def __init__(self, job_id: str, command_id: str, command_timeout: timedelta = COMMAND_STATUS_TIMEOUT):
+    def __init__(
+        self,
+        job_id: str,
+        command_id: str,
+        command_timeout: timedelta = COMMAND_STATUS_TIMEOUT,
+    ):
         self._command_timeout = command_timeout
         self._job_id = job_id
         self._command_id = command_id

--- a/file_writer_control/JobHandler.py
+++ b/file_writer_control/JobHandler.py
@@ -76,6 +76,12 @@ class JobHandler:
             current_status.service_id, self._job_id, stop_time
         )
 
+    def stop_now(self) -> Union[CommandHandler, None]:
+        """
+        See the documentation for abort_write_job().
+        """
+        return self.abort_write_job()
+
     def abort_write_job(self) -> Union[CommandHandler, None]:
         """
         Tell the file-writing to abort writing. There is no guarantee that will actually happen though.

--- a/file_writer_control/WorkerFinder.py
+++ b/file_writer_control/WorkerFinder.py
@@ -68,6 +68,12 @@ class WorkerFinderBase:
         self.send_command(message)
         return CommandHandler(self.command_channel, command_id)
 
+    def try_send_stop_now(self, service_id: str, job_id: str) -> CommandHandler:
+        """
+        See documentation for `try_send_abort()`.
+        """
+        return self.try_send_abort(service_id, job_id)
+
     def try_send_abort(self, service_id: str, job_id: str) -> CommandHandler:
         """
         Sends a "abort" message to a file-writer running a job as identified by the parameters of this function.

--- a/file_writer_control/WorkerJobPool.py
+++ b/file_writer_control/WorkerJobPool.py
@@ -42,6 +42,7 @@ class WorkerJobPool(WorkerFinder):
         """
         See base class for documentation.
         """
+        self.command_channel.add_job_id(job.job_id)
         self.command_channel.add_command_id(job.job_id, job.job_id)
         self.command_channel.get_command(
             job.job_id

--- a/file_writer_control/_version.py
+++ b/file_writer_control/_version.py
@@ -1,4 +1,4 @@
 # Version is not directly defined in __init__ because that causes all
 # run time dependencies to become build-time dependencies when it is
 # imported in setup.py
-version = "1.1.6"
+version = "1.1.7"

--- a/file_writer_control/_version.py
+++ b/file_writer_control/_version.py
@@ -1,4 +1,4 @@
 # Version is not directly defined in __init__ because that causes all
 # run time dependencies to become build-time dependencies when it is
 # imported in setup.py
-version = "1.1.5"
+version = "1.1.6"

--- a/tests/test_command_status.py
+++ b/tests/test_command_status.py
@@ -1,6 +1,10 @@
 import pytest
 
-from file_writer_control.CommandStatus import CommandState, CommandStatus, COMMAND_STATUS_TIMEOUT
+from file_writer_control.CommandStatus import (
+    CommandState,
+    CommandStatus,
+    COMMAND_STATUS_TIMEOUT,
+)
 from datetime import timedelta
 
 

--- a/tests/test_command_status.py
+++ b/tests/test_command_status.py
@@ -1,6 +1,7 @@
 import pytest
 
-from file_writer_control.CommandStatus import CommandState, CommandStatus
+from file_writer_control.CommandStatus import CommandState, CommandStatus, COMMAND_STATUS_TIMEOUT
+from datetime import timedelta
 
 
 def test_init():
@@ -47,6 +48,20 @@ def test_update_success():
     under_test1 = CommandStatus("job_id1", "command_id1")
     under_test2 = CommandStatus("job_id1", "command_id1")
     under_test2.update_status(under_test1)  # No exception
+
+
+def test_timeout1():
+    under_test = CommandStatus("job_id1", "command_id1")
+    assert under_test.timeout == COMMAND_STATUS_TIMEOUT
+
+
+def test_timeout2():
+    test_time = timedelta(minutes=2)
+    under_test = CommandStatus("job_id1", "command_id1", test_time)
+    assert under_test.timeout == test_time
+    test_time2 = timedelta(seconds=30)
+    under_test.timeout = test_time2
+    assert under_test.timeout == test_time2
 
 
 def test_update_message():


### PR DESCRIPTION
## Some comments

The build currently fails (as of the 17th of august) due to a Jenkins issue. It looks like this build failure is due to a bug in the library that we use for creating Jenkins jobs.

I had to revert the removal of some function names as there were projects depending on this library that started failing due to those changes. In my opinion; changing the interface of a library that is in use should usually be avoided. When it cannot be avoided, try to mark an old interface as deprecated before removing it.

## Changes

* Added some documentation
* Reverted removal of functions
* Fixed serious `datetime` bug
* Fixed initial `CommandState` issue
* Added code for modifying the command response timeout