### PR TITLE
Fix: Do not require service_id on run stop commands

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Version changes
 
+## Version 1.2.4
+* Do not require service_id in run stop commands, as per 6s4t schema.
+
 ## Version 1.2.3
 * Increased the maximum size of received messages and the command status timeout.
 

--- a/file_writer_control/InThreadStatusTracker.py
+++ b/file_writer_control/InThreadStatusTracker.py
@@ -163,7 +163,10 @@ class InThreadStatusTracker:
         current_command.message = answer.message
         current_command.response_code = Response.status_code
         self.known_jobs[answer.job_id].message = answer.message
-        self.known_jobs[answer.job_id].service_id = answer.service_id
+        try:
+            self.known_jobs[answer.job_id].service_id = answer.service_id
+        except RuntimeError:
+            pass
 
     def process_status(self, status_update: StatusMessage):
         """

--- a/file_writer_control/JobHandler.py
+++ b/file_writer_control/JobHandler.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from typing import Union
 
 from file_writer_control.CommandHandler import CommandHandler
 from file_writer_control.JobStatus import JobState

--- a/file_writer_control/JobHandler.py
+++ b/file_writer_control/JobHandler.py
@@ -60,7 +60,7 @@ class JobHandler:
             return ""
         return current_status.message
 
-    def set_stop_time(self, stop_time: datetime) -> Union[CommandHandler, None]:
+    def set_stop_time(self, stop_time: datetime) -> CommandHandler:
         """
         Set a new stop time for the file-writing job. There is no guarantee that the stop time will actually be changed.
         This call is not blocking. Calling this member function will have no effect on the stop-time before the write
@@ -76,13 +76,13 @@ class JobHandler:
             stop_time,
         )
 
-    def stop_now(self) -> Union[CommandHandler, None]:
+    def stop_now(self) -> CommandHandler:
         """
         See the documentation for abort_write_job().
         """
         return self.abort_write_job()
 
-    def abort_write_job(self) -> Union[CommandHandler, None]:
+    def abort_write_job(self) -> CommandHandler:
         """
         Tell the file-writing to abort writing. There is no guarantee that will actually happen though.
         This call is not blocking. Calling this member function will have no effect if done before a write job has

--- a/file_writer_control/JobHandler.py
+++ b/file_writer_control/JobHandler.py
@@ -70,10 +70,10 @@ class JobHandler:
         :return: A CommandHandler instance that can be used to monitor the outcome of the attempt to set a new stop time.
         """
         current_status = self.worker_finder.get_job_status(self._job_id)
-        if current_status is None:
-            return None
         return self.worker_finder.try_send_stop_time(
-            current_status.service_id, self._job_id, stop_time
+            current_status.service_id if current_status else None,
+            self._job_id,
+            stop_time,
         )
 
     def stop_now(self) -> Union[CommandHandler, None]:
@@ -91,10 +91,8 @@ class JobHandler:
         :return: A CommandHandler instance that can be used to monitor the outcome of the attempt to set a new stop time.
         """
         current_status = self.worker_finder.get_job_status(self._job_id)
-        if current_status is None:
-            return None
         return self.worker_finder.try_send_abort(
-            current_status.service_id, self._job_id
+            current_status.service_id if current_status else None, self._job_id
         )
 
     @property

--- a/file_writer_control/WorkerFinder.py
+++ b/file_writer_control/WorkerFinder.py
@@ -1,6 +1,6 @@
 import uuid
 from datetime import datetime
-from typing import List
+from typing import List, Optional
 
 from kafka import KafkaProducer
 from kafka.errors import NoBrokersAvailable
@@ -47,12 +47,12 @@ class WorkerFinderBase:
         raise NotImplementedError("Not implemented in base class.")
 
     def try_send_stop_time(
-        self, service_id: str, job_id: str, stop_time: datetime
+        self, service_id: Optional[str], job_id: str, stop_time: datetime
     ) -> CommandHandler:
         """
         Sends a "set stop time" message to a file-writer running a job as identified by the parameters.
         This function is not blocking. No guarantees are given that this command will be followed.
-        :param service_id: The service identifier of the file-writer to receive the command.
+        :param service_id: The (optional) service identifier of the file-writer to receive the command.
         :param job_id: The job identifier of the currently running file-writer job.
         :param stop_time: The new stop time.
         :return: A CommandHandler instance for (more) easily checking the outcome of setting a new stop time.
@@ -68,17 +68,19 @@ class WorkerFinderBase:
         self.send_command(message)
         return CommandHandler(self.command_channel, command_id)
 
-    def try_send_stop_now(self, service_id: str, job_id: str) -> CommandHandler:
+    def try_send_stop_now(
+        self, service_id: Optional[str], job_id: str
+    ) -> CommandHandler:
         """
         See documentation for `try_send_abort()`.
         """
         return self.try_send_abort(service_id, job_id)
 
-    def try_send_abort(self, service_id: str, job_id: str) -> CommandHandler:
+    def try_send_abort(self, service_id: Optional[str], job_id: str) -> CommandHandler:
         """
         Sends a "abort" message to a file-writer running a job as identified by the parameters of this function.
         This function is not blocking. No guarantees are given that this command will be followed.
-        :param service_id: The service identifier of the file-writer to receive the command.
+        :param service_id: The (optional) service identifier of the file-writer to receive the command.
         :param job_id: The job identifier of the currently running file-writer job.
         :return: A CommandHandler instance for (more) easily checking the outcome of the "abort" command.
         """

--- a/file_writer_control/_version.py
+++ b/file_writer_control/_version.py
@@ -1,4 +1,4 @@
 # Version is not directly defined in __init__ because that causes all
 # run time dependencies to become build-time dependencies when it is
 # imported in setup.py
-version = "1.2.3"
+version = "1.2.4"

--- a/tests/test_job_handler.py
+++ b/tests/test_job_handler.py
@@ -54,21 +54,18 @@ def test_error_string_with_id():
     worker_finder_mock.get_job_status.assert_called_once_with(test_job.job_id)
 
 
-def test_set_stop_time_no_id():
-    worker_finder_mock = Mock()
-    test_job = WriteJob("{}", "some_file_name", "some_broker", datetime.now())
-    worker_finder_mock.get_job_status.return_value = None
-    under_test = JobHandler(worker_finder_mock)
-    under_test.start_job(test_job)
-    test_stop_time = datetime.now()
-    assert under_test.set_stop_time(test_stop_time) is None
-
-
-def test_set_stop_time_with_id():
+@pytest.mark.parametrize(
+    "service_id",
+    [
+        None,
+        "some_service_id",
+    ],
+)
+def test_set_stop_time(service_id):
     worker_finder_mock = Mock()
     test_job = WriteJob("{}", "some_file_name", "some_broker", datetime.now())
     test_job_status = JobStatus(test_job.job_id)
-    test_job_status.service_id = "some_service_id"
+    test_job_status.service_id = service_id
     worker_finder_mock.get_job_status.return_value = test_job_status
     under_test = JobHandler(worker_finder_mock)
     under_test.start_job(test_job)
@@ -82,20 +79,18 @@ def test_set_stop_time_with_id():
     )
 
 
-def test_abort_write_job_no_id():
-    worker_finder_mock = Mock()
-    test_job = WriteJob("{}", "some_file_name", "some_broker", datetime.now())
-    worker_finder_mock.get_job_status.return_value = None
-    under_test = JobHandler(worker_finder_mock)
-    under_test.start_job(test_job)
-    assert under_test.abort_write_job() is None
-
-
-def test_abort_write_job_with_id():
+@pytest.mark.parametrize(
+    "service_id",
+    [
+        None,
+        "some_service_id",
+    ],
+)
+def test_abort_write_job_with_id(service_id):
     worker_finder_mock = Mock()
     test_job = WriteJob("{}", "some_file_name", "some_broker", datetime.now())
     test_job_status = JobStatus(test_job.job_id)
-    test_job_status.service_id = "some_service_id"
+    test_job_status.service_id = service_id
     worker_finder_mock.get_job_status.return_value = test_job_status
     under_test = JobHandler(worker_finder_mock)
     under_test.start_job(test_job)

--- a/tests/test_job_handler.py
+++ b/tests/test_job_handler.py
@@ -86,7 +86,7 @@ def test_set_stop_time(service_id):
         "some_service_id",
     ],
 )
-def test_abort_write_job_with_id(service_id):
+def test_abort_write_job(service_id):
     worker_finder_mock = Mock()
     test_job = WriteJob("{}", "some_file_name", "some_broker", datetime.now())
     test_job_status = JobStatus(test_job.job_id)

--- a/tests/test_worker_finder.py
+++ b/tests/test_worker_finder.py
@@ -28,8 +28,14 @@ def test_try_start_job():
         under_test.try_start_job(WriteJob("", "", "", datetime.now()))
 
 
-def test_try_send_stop_time():
-    service_id = "some service_id"
+@pytest.mark.parametrize(
+    "service_id",
+    [
+        None,
+        "some_service_id",
+    ],
+)
+def test_try_send_stop_time(service_id):
     job_id = "some job id"
     cmd_channel_mock = Mock()
     producer_mock = Mock()
@@ -44,14 +50,22 @@ def test_try_send_stop_time():
     topic_name = producer_mock.send.call_args_list[0].args[0]
     assert topic_name == test_topic
     message = deserialise_stop(producer_mock.send.call_args_list[0].args[1])
-    assert message.service_id == service_id
+    assert message.service_id == service_id or (
+        service_id is None and message.service_id == ""
+    )
     assert message.job_id == job_id
     assert message.command_id == result.command_id
     assert message.stop_time == int(stop_time.timestamp() * 1000)
 
 
-def test_try_abort_job_now():
-    service_id = "some service_id"
+@pytest.mark.parametrize(
+    "service_id",
+    [
+        None,
+        "some_service_id",
+    ],
+)
+def test_try_abort_job_now(service_id):
     job_id = "some job id"
     cmd_channel_mock = Mock()
     producer_mock = Mock()
@@ -65,7 +79,9 @@ def test_try_abort_job_now():
     topic_name = producer_mock.send.call_args_list[0].args[0]
     assert topic_name == test_topic
     message = deserialise_stop(producer_mock.send.call_args_list[0].args[1])
-    assert message.service_id == service_id
+    assert message.service_id == service_id or (
+        service_id is None and message.service_id == ""
+    )
     assert message.job_id == job_id
     assert message.command_id == result.command_id
 


### PR DESCRIPTION
6s4t_run_stop sets the field as optional.
The file writer used to require it, but that is now changing.