### PR TITLE
The example script `list_status.py` output is fixed, and a new example is added which can stop a running writer-job

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -28,11 +28,10 @@ job_handler = JobHandler(worker_finder=worker_pool)
 job_handler.start_job(WriteJob(nexus_structure="{...}", "file.nxs", "dmsc-kafka01:9092", datetime.now()))
 ```
 
-You can also stop jobs by modifying the final line to:
+You can also stop jobs via the use of:
 
 ```python
-for job in worker_pool.list_known_jobs():
-    worker_pool.try_send_stop_now(job.service_id, job.job_id)
+stop_write_job_now(job_handler)
 ```
 
 ## Find which workers are available

--- a/examples/README.md
+++ b/examples/README.md
@@ -28,9 +28,16 @@ job_handler = JobHandler(worker_finder=worker_pool)
 job_handler.start_job(WriteJob(nexus_structure="{...}", "file.nxs", "dmsc-kafka01:9092", datetime.now()))
 ```
 
+You can also stop jobs by modifying the final line to:
+
+```python
+for job in worker_pool.list_known_jobs():
+    worker_pool.try_send_stop_now(job.service_id, job.job_id)
+```
+
 ## Find which workers are available
 
-It is possible to list currently known workers using the `WorkerJobPool` class. This is done as follows (also in [*list_status.py*](list_workers.py)):
+It is possible to list currently known workers using the `WorkerJobPool` class. This is done as follows (also in [*list_status.py*](list_status.py)):
 
 ```python
 from file_writer_control.WorkerJobPool import WorkerJobPool

--- a/examples/kill_writer.py
+++ b/examples/kill_writer.py
@@ -1,0 +1,27 @@
+import time
+
+from file_writer_control import WorkerJobPool
+
+
+def kill_job(pool: WorkerJobPool, service_id: str, job_id: str):
+    result = pool.try_send_stop_now(service_id, job_id)
+
+
+def main():
+    from argparse import ArgumentParser
+    parser = ArgumentParser()
+    parser.add_argument('-b', '--broker', help="Kafka broker", default='localhost:9092', type=str)
+    parser.add_argument('-c', '--command', help="Writer command topic", default="WriterCommand", type=str)
+    parser.add_argument('-t', '--topic', help='Writer job topic', default='WriterJobs', type=str)
+    parser.add_argument('-s', '--sleep', help='Post pool creation sleep time (s)', default=1, type=int)
+    parser.add_argument('service_id', type=str, help='Writer service id to stop')
+    parser.add_argument('job_id', type=str, help='Writer job id to stop')
+
+    args = parser.parse_args()
+    pool = WorkerJobPool(f'{args.broker}/{args.topic}', f'{args.broker}/{args.command}')
+    time.sleep(args.sleep)
+    kill_job(pool, args.service_id, args.job_id)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The output of `list_status.py` uses fixed-width string format specifications to display information about known `service_id`, `job_id` and `command_id` lists for a `WorkerJobPool`.
If any of these ids (or data printed about them) is wider than the format specifier the information presented can run-together, making them impossible to distinguish.

Additionally, the `WorkerJobPool` configuration is fixed, limiting the utility of this example as a command line utility in a test environment.

This PR makes the configuration accessible via command line arguments, and formats the output to avoid running-together columns.

Output now looks like:
```cmd
$ python list_status.py 
Known workers
Service id                              Current state       
--------------------------------------- ------------------- 
kafka-to-nexus:551c3c39d706-pid:13-7a1e WorkerState.WRITING 

Known jobs
Service id                              Job id                               Current state    File name or message       
--------------------------------------- ------------------------------------ ---------------- -------------------- 
kafka-to-nexus:551c3c39d706-pid:13-7a1e b750ba90-d1cc-11ee-9ced-a4bb6dcfdfaf JobState.WRITING filename.h5 

Known commands
```

--
A new example script is added to allow for easily killing 'stuck' file-writer jobs if, e.g., an under-development feature in `kafka-to-nexus` causes the file-writer to enter an infinite loop.

The new script takes command line input designed to match the output of the updated `list_status.py` command, e.g.,

```cmd
$ python kill_writer.py kafka-to-nexus:551c3c39d706-pid:13-7a1e b750ba90-d1cc-11ee-9ced-a4bb6dcfdfaf 
```
to allow for easy copy-and-paste interaction.
